### PR TITLE
Bug Fix - Logger Usafe

### DIFF
--- a/src/common/Logger.ts
+++ b/src/common/Logger.ts
@@ -1,6 +1,6 @@
 import { ILogEvent } from "../models/ILogEvent";
 import { JWT_MESSAGE } from "../models/enums";
-import { logError } from "../functions/authorizer";
+import { ILogError } from "../models/ILogError";
 
 export const writeLogMessage = (log: ILogEvent, error?: any) => {
   if (!error) {
@@ -8,6 +8,7 @@ export const writeLogMessage = (log: ILogEvent, error?: any) => {
     console.log(log);
   } else {
     log.statusCode = 401;
+    const logError: ILogError = {};
     switch (error.name) {
       case "TokenExpiredError":
         logError.name = "TokenExpiredError";

--- a/src/functions/authorizer.ts
+++ b/src/functions/authorizer.ts
@@ -103,7 +103,7 @@ const newPolicyDocument = (statements: Statement[]): PolicyDocument => {
   };
 };
 
-const reportNoValidRoles = (jwt: any, event: APIGatewayTokenAuthorizerEvent, context: Context, logEvent:ILogEvent): void => {
+const reportNoValidRoles = (jwt: any, event: APIGatewayTokenAuthorizerEvent, context: Context, logEvent: ILogEvent): void => {
   const roles = jwt.payload.roles;
   if (roles && roles.length === 0) {
     logEvent.message = JWT_MESSAGE.NO_ROLES;
@@ -116,9 +116,9 @@ const reportNoValidRoles = (jwt: any, event: APIGatewayTokenAuthorizerEvent, con
  * This method is being used in order to clear the ILogEvent, ILogError objects and populate the request url and the time of request
  * @param event
  */
-const initialiseLogEvent = (event: APIGatewayTokenAuthorizerEvent):ILogEvent => {
-return {
+const initialiseLogEvent = (event: APIGatewayTokenAuthorizerEvent): ILogEvent => {
+  return {
     requestUrl: event.methodArn,
-    timeOfRequest: new Date().toISOString()
+    timeOfRequest: new Date().toISOString(),
   };
 };

--- a/src/services/roles.ts
+++ b/src/services/roles.ts
@@ -13,7 +13,7 @@ export default interface Role {
 
 const backwardsCompatibleRoleNames = ["CVSFullAccess", "CVSPsvTester", "CVSHgvTester", "CVSAdrTester", "CVSTirTester", "VTMAdmin"];
 
-export const getValidRoles = (token: any, logEvent:ILogEvent): Role[] => {
+export const getValidRoles = (token: any, logEvent: ILogEvent): Role[] => {
   const rolesOnToken = token.payload.roles;
 
   if (!rolesOnToken) {

--- a/src/services/roles.ts
+++ b/src/services/roles.ts
@@ -1,4 +1,4 @@
-import { logEvent } from "../functions/authorizer";
+import { ILogEvent } from "../models/ILogEvent";
 
 export type Access = "read" | "write" | "view";
 
@@ -13,7 +13,7 @@ export default interface Role {
 
 const backwardsCompatibleRoleNames = ["CVSFullAccess", "CVSPsvTester", "CVSHgvTester", "CVSAdrTester", "CVSTirTester", "VTMAdmin"];
 
-export const getValidRoles = (token: any): Role[] => {
+export const getValidRoles = (token: any, logEvent:ILogEvent): Role[] => {
   const rolesOnToken = token.payload.roles;
 
   if (!rolesOnToken) {

--- a/src/services/tokens.ts
+++ b/src/services/tokens.ts
@@ -1,12 +1,11 @@
 import * as JWT from "jsonwebtoken";
 import { JWT_MESSAGE } from "../models/enums";
-import { logEvent } from "../functions/authorizer";
+import { ILogEvent } from "../models/ILogEvent";
 
-export const getValidJwt = (authorizationToken: string): any => {
+export const getValidJwt = (authorizationToken: string, logEvent:ILogEvent): any => {
   checkFormat(authorizationToken);
 
   authorizationToken = authorizationToken.substring(7); // remove 'Bearer '
-  logEvent.token = authorizationToken;
 
   const decoded: any = JWT.decode(authorizationToken, { complete: true });
 

--- a/src/services/tokens.ts
+++ b/src/services/tokens.ts
@@ -2,7 +2,7 @@ import * as JWT from "jsonwebtoken";
 import { JWT_MESSAGE } from "../models/enums";
 import { ILogEvent } from "../models/ILogEvent";
 
-export const getValidJwt = (authorizationToken: string, logEvent:ILogEvent): any => {
+export const getValidJwt = (authorizationToken: string, logEvent: ILogEvent): any => {
   checkFormat(authorizationToken);
 
   authorizationToken = authorizationToken.substring(7); // remove 'Bearer '

--- a/tests/unit/functions/authoriser.unitTest.ts
+++ b/tests/unit/functions/authoriser.unitTest.ts
@@ -51,7 +51,7 @@ describe("authorizer() unit tests", () => {
     const returnValue: APIGatewayAuthorizerResult = await authorizer(event, exampleContext());
 
     expect(returnValue.principalId).toEqual(jwtJson.payload.sub);
-    expect(returnValue.policyDocument.Statement.length).toEqual(2)
+    expect(returnValue.policyDocument.Statement.length).toEqual(2);
     expect(returnValue.policyDocument.Statement).toContainEqual({
       Effect: "Allow",
       Action: "execute-api:Invoke",
@@ -62,7 +62,6 @@ describe("authorizer() unit tests", () => {
       Action: "execute-api:Invoke",
       Resource: `arn:aws:execute-api:eu-west-1:*:*/*/HEAD/a-resource/with-child`,
     });
-
   });
 
   it("should return valid write statements on valid JWT", async () => {

--- a/tests/unit/services/roles.unitTest.ts
+++ b/tests/unit/services/roles.unitTest.ts
@@ -2,7 +2,7 @@ import Role, { getValidRoles } from "../../../src/services/roles";
 
 describe("getValidRoles()", () => {
   it("should return list of valid roles if there are any", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles(["name1.read", "name2.WRITE"]));
+    const roles: Role[] = getValidRoles(tokenWithRoles(["name1.read", "name2.WRITE"]), {});
     expect(roles.length).toEqual(2);
 
     expect(roles).toContainEqual({
@@ -16,7 +16,7 @@ describe("getValidRoles()", () => {
   });
 
   it("should return list of valid roles for TechRecord.View", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles(["TechRecord.View"]));
+    const roles: Role[] = getValidRoles(tokenWithRoles(["TechRecord.View"]), {});
     expect(roles.length).toEqual(1);
 
     expect(roles).toContainEqual({
@@ -26,7 +26,7 @@ describe("getValidRoles()", () => {
   });
 
   it("should return backwards-compatible roles with write access", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles(["CVSFullAccess"]));
+    const roles: Role[] = getValidRoles(tokenWithRoles(["CVSFullAccess"]), {});
 
     expect(roles.length).toEqual(1);
 
@@ -37,49 +37,49 @@ describe("getValidRoles()", () => {
   });
 
   it("should return empty list if no roles on token", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles([]));
+    const roles: Role[] = getValidRoles(tokenWithRoles([]), {});
 
     expect(roles.length).toEqual(0);
   });
 
   it("should return empty list if invalid role", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles(["invalid"]));
+    const roles: Role[] = getValidRoles(tokenWithRoles(["invalid"]), {});
 
     expect(roles.length).toEqual(0);
   });
 
   it("should return empty list if too many parts", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles(["part1.part2.part3"]));
+    const roles: Role[] = getValidRoles(tokenWithRoles(["part1.part2.part3"]), {});
 
     expect(roles.length).toEqual(0);
   });
 
   it("should return empty list if null name", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles([".read"]));
+    const roles: Role[] = getValidRoles(tokenWithRoles([".read"]), {});
 
     expect(roles.length).toEqual(0);
   });
 
   it("should return empty list if null access", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles(["name."]));
+    const roles: Role[] = getValidRoles(tokenWithRoles(["name."]), {});
 
     expect(roles.length).toEqual(0);
   });
 
   it("should return empty list if both parts null", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles(["."]));
+    const roles: Role[] = getValidRoles(tokenWithRoles(["."]), {});
 
     expect(roles.length).toEqual(0);
   });
 
   it("should return empty list if access incorrect", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles(["name.not-read-and-not-write"]));
+    const roles: Role[] = getValidRoles(tokenWithRoles(["name.not-read-and-not-write"]), {});
 
     expect(roles.length).toEqual(0);
   });
 
   it("should consider name case-sensitive", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles(["NaMe.read", "nAmE.read"]));
+    const roles: Role[] = getValidRoles(tokenWithRoles(["NaMe.read", "nAmE.read"]), {});
 
     expect(roles.length).toEqual(2);
 
@@ -94,7 +94,7 @@ describe("getValidRoles()", () => {
   });
 
   it("should consider access case-insensitive", () => {
-    const roles: Role[] = getValidRoles(tokenWithRoles(["name.READ", "name.WRITE"]));
+    const roles: Role[] = getValidRoles(tokenWithRoles(["name.READ", "name.WRITE"]), {});
 
     expect(roles.length).toEqual(2);
 

--- a/tests/unit/services/tokens.unitTest.ts
+++ b/tests/unit/services/tokens.unitTest.ts
@@ -4,31 +4,31 @@ import { JWT_MESSAGE } from "../../../src/models/enums";
 describe("getValidJwt()", () => {
   it("should fail on blank authorization token", async () => {
     expect(() => {
-      getValidJwt("");
+      getValidJwt("", {});
     }).toThrowError(JWT_MESSAGE.NO_AUTH_HEADER);
   });
 
   it("should fail on non-Bearer authorization token", async () => {
     expect(() => {
-      getValidJwt("not a Bearer");
+      getValidJwt("not a Bearer", {});
     }).toThrowError(JWT_MESSAGE.NO_BEARER_PREFIX);
   });
 
   it("should fail when Bearer prefix is present, but token value isn't", async () => {
     expect(() => {
-      getValidJwt("Bearer");
+      getValidJwt("Bearer", {});
     }).toThrowError(JWT_MESSAGE.BLANK_TOKEN);
   });
 
   it("should fail when Bearer prefix is present, but token value is blank", async () => {
     expect(() => {
-      getValidJwt("Bearer      ");
+      getValidJwt("Bearer      ", {});
     }).toThrowError(JWT_MESSAGE.BLANK_TOKEN);
   });
 
   it("should fail on invalid JWT token", async () => {
     expect(() => {
-      getValidJwt("Bearer invalidJwt");
+      getValidJwt("Bearer invalidJwt", {});
     }).toThrowError(JWT_MESSAGE.DECODE_FAILED);
   });
 
@@ -37,7 +37,7 @@ describe("getValidJwt()", () => {
     const payload = "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ0aWQiOiIxMjM0NTYiLCJleHAiOjYzMTAwNTMzNH0";
     const signature = "DUmbnmFG6y-AxpT578vTwVeHoT04LyAwcdhDdvxby_A";
 
-    expect(getValidJwt(`Bearer ${header}.${payload}.${signature}`)).toMatchObject({
+    expect(getValidJwt(`Bearer ${header}.${payload}.${signature}`, {})).toMatchObject({
       header: {
         kid: "ABCDEF",
       },
@@ -52,7 +52,7 @@ describe("getValidJwt()", () => {
     const payload = "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ0aWQiOiIxMjM0NTYiLCJleHAiOjYzMTAwNTMzNCwidW5pcXVlX25hbWUiOiJ0ZXN0In0";
     const signature = "DUmbnmFG6y-AxpT578vTwVeHoT04LyAwcdhDdvxby_A";
 
-    expect(getValidJwt(`Bearer ${header}.${payload}.${signature}`)).toMatchObject({
+    expect(getValidJwt(`Bearer ${header}.${payload}.${signature}`, {})).toMatchObject({
       header: {
         kid: "ABCDEF",
       },
@@ -68,7 +68,7 @@ describe("getValidJwt()", () => {
     const payload = "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ0aWQiOiIxMjM0NTYiLCJleHAiOjYzMTAwNTMzNCwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdCJ9";
     const signature = "DUmbnmFG6y-AxpT578vTwVeHoT04LyAwcdhDdvxby_A";
 
-    expect(getValidJwt(`Bearer ${header}.${payload}.${signature}`)).toMatchObject({
+    expect(getValidJwt(`Bearer ${header}.${payload}.${signature}`, {})).toMatchObject({
       header: {
         kid: "ABCDEF",
       },


### PR DESCRIPTION
## Update use of logEvent
* **Remove function level exports**
meant one logEvent object was being shared between all invocations, so logging is potentially inaccurate
* **Remove "dump" method**
Outputs entire request input - including valid OAuth2 tokens for users, bad security. Email and expiry are being output with an error message, that's already quite a lot
* **Remove token being stored in log object**
Invalid token for the authoriser doesn't stop them being valid tokens for our users - shouldn't be placed in console log
* **Moved ILogError - only created or set in one method, shouldn't be function level object**