### PR TITLE
Fix multiple auth paths

### DIFF
--- a/src/services/signature-check.ts
+++ b/src/services/signature-check.ts
@@ -6,8 +6,8 @@ export const checkSignature = async (encodedToken: string, decodedToken: JWT.Jwt
   const certificate = await getCertificateChain(tenantId, decodedToken.header.kid as string);
 
   JWT.verify(encodedToken, certificate, {
-    audience: clientId.split(','),
-    issuer: [`https://sts.windows.net/${tenantId}/`,`https://login.microsoftonline.com/${tenantId}/v2.0`],
+    audience: clientId.split(","),
+    issuer: [`https://sts.windows.net/${tenantId}/`, `https://login.microsoftonline.com/${tenantId}/v2.0`],
     algorithms: ["RS256"],
   });
 };

--- a/src/services/signature-check.ts
+++ b/src/services/signature-check.ts
@@ -6,8 +6,8 @@ export const checkSignature = async (encodedToken: string, decodedToken: JWT.Jwt
   const certificate = await getCertificateChain(tenantId, decodedToken.header.kid as string);
 
   JWT.verify(encodedToken, certificate, {
-    audience: clientId,
-    issuer: `https://sts.windows.net/${tenantId}/`,
+    audience: clientId.split(','),
+    issuer: [`https://sts.windows.net/${tenantId}/`,`https://login.microsoftonline.com/${tenantId}/v2.0`],
     algorithms: ["RS256"],
   });
 };

--- a/tests/unit/services/signature-check.unitTest.ts
+++ b/tests/unit/services/signature-check.unitTest.ts
@@ -23,9 +23,25 @@ describe("checkSignature()", () => {
     await expect(checkSignature(`${header}.${payload}.${signature}`, jwtJson, DEFAULT_TENANT_ID, DEFAULT_CLIENT_ID)).resolves.not.toThrowError();
 
     expect(jsonWebToken.verify).toBeCalledWith(`${header}.${payload}.${signature}`, "fake certificate", {
-      audience: DEFAULT_CLIENT_ID,
-      issuer: `https://sts.windows.net/${DEFAULT_TENANT_ID}/`,
+      audience: [DEFAULT_CLIENT_ID],
+      issuer: [`https://sts.windows.net/${DEFAULT_TENANT_ID}/`,`https://login.microsoftonline.com/${DEFAULT_TENANT_ID}/v2.0`],
+      algorithms: ["RS256"],
+    });
+  });
+
+  it("should successfully verify multiple clients", async () => {
+    const header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IkFCQ0RFRiJ9";
+    const payload = "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ0aWQiOiIxMjM0NTYifQ";
+    const signature = "DUmbnmFG6y-AxpT578vTwVeHoT04LyAwcdhDdvxby_A";
+
+    await expect(checkSignature(`${header}.${payload}.${signature}`, jwtJson, DEFAULT_TENANT_ID, DEFAULT_CLIENT_ID + ',xxxx')).resolves.not.toThrowError();
+
+    expect(jsonWebToken.verify).toBeCalledWith(`${header}.${payload}.${signature}`, "fake certificate", {
+      audience: [DEFAULT_CLIENT_ID,'xxxx'],
+      issuer: [`https://sts.windows.net/${DEFAULT_TENANT_ID}/`,`https://login.microsoftonline.com/${DEFAULT_TENANT_ID}/v2.0`],
       algorithms: ["RS256"],
     });
   });
 });
+
+

--- a/tests/unit/services/signature-check.unitTest.ts
+++ b/tests/unit/services/signature-check.unitTest.ts
@@ -24,7 +24,7 @@ describe("checkSignature()", () => {
 
     expect(jsonWebToken.verify).toBeCalledWith(`${header}.${payload}.${signature}`, "fake certificate", {
       audience: [DEFAULT_CLIENT_ID],
-      issuer: [`https://sts.windows.net/${DEFAULT_TENANT_ID}/`,`https://login.microsoftonline.com/${DEFAULT_TENANT_ID}/v2.0`],
+      issuer: [`https://sts.windows.net/${DEFAULT_TENANT_ID}/`, `https://login.microsoftonline.com/${DEFAULT_TENANT_ID}/v2.0`],
       algorithms: ["RS256"],
     });
   });
@@ -34,14 +34,12 @@ describe("checkSignature()", () => {
     const payload = "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJ0aWQiOiIxMjM0NTYifQ";
     const signature = "DUmbnmFG6y-AxpT578vTwVeHoT04LyAwcdhDdvxby_A";
 
-    await expect(checkSignature(`${header}.${payload}.${signature}`, jwtJson, DEFAULT_TENANT_ID, DEFAULT_CLIENT_ID + ',xxxx')).resolves.not.toThrowError();
+    await expect(checkSignature(`${header}.${payload}.${signature}`, jwtJson, DEFAULT_TENANT_ID, DEFAULT_CLIENT_ID + ",xxxx")).resolves.not.toThrowError();
 
     expect(jsonWebToken.verify).toBeCalledWith(`${header}.${payload}.${signature}`, "fake certificate", {
-      audience: [DEFAULT_CLIENT_ID,'xxxx'],
-      issuer: [`https://sts.windows.net/${DEFAULT_TENANT_ID}/`,`https://login.microsoftonline.com/${DEFAULT_TENANT_ID}/v2.0`],
+      audience: [DEFAULT_CLIENT_ID, "xxxx"],
+      issuer: [`https://sts.windows.net/${DEFAULT_TENANT_ID}/`, `https://login.microsoftonline.com/${DEFAULT_TENANT_ID}/v2.0`],
       algorithms: ["RS256"],
     });
   });
 });
-
-


### PR DESCRIPTION
VTM and VTA are currently authenticating differently which requires an update

* Both issuers are now mapped to the issuer field
* Comma delimited client IDs will allow multiple clients within the same tenant to be validated