### PR TITLE
feat(cb2-6718): snyk now uses v2 instead of main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   security:
-    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@main
+    uses: dvsa/.github/.github/workflows/nodejs-security.yaml@v2
     with:
       args: '--all-projects'
     secrets:


### PR DESCRIPTION
## CB2-6718 - Add Snyk and remove Dependandabot from existing Node repos

_Replacing Dependabot with Snyk_
[CB2-6718](https://dvsa.atlassian.net/browse/CB2-6718)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
