### PR TITLE
dedupe policy statements

### DIFF
--- a/src/functions/functionalPolicyFactory.ts
+++ b/src/functions/functionalPolicyFactory.ts
@@ -17,7 +17,9 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     .map((i: IApiAccess[]) => i.map((ia) => toStatements(ia)).flat())
     .flat();
 
-    const dedupedFilters = statements.filter((item:MaybeStatementResource, pos:number, self:MaybeStatementResource[]) => { return self.findIndex(s => s.Resource === item.Resource) === pos });
+  const dedupedFilters = statements.filter((item: MaybeStatementResource, pos: number, self: MaybeStatementResource[]) => {
+    return self.findIndex((s) => s.Resource === item.Resource) === pos;
+  });
 
   if (dedupedFilters.length === 0) {
     return undefined;

--- a/src/functions/functionalPolicyFactory.ts
+++ b/src/functions/functionalPolicyFactory.ts
@@ -1,9 +1,10 @@
-import { APIGatewayAuthorizerResult, Statement } from "aws-lambda";
+import { APIGatewayAuthorizerResult, MaybeStatementResource, Statement, StatementResource } from "aws-lambda";
 import newPolicyDocument from "./newPolicyDocument";
 import { ILogEvent } from "../models/ILogEvent";
 import StatementBuilder from "../services/StatementBuilder";
 import { functionConfig, IApiAccess } from "./functionalConfig";
 import { Jwt, JwtPayload } from "jsonwebtoken";
+import { ResourceStatement } from "aws-sdk/clients/ec2";
 
 function toStatements(access: IApiAccess): Statement[] {
   return access.verbs.map((v) => new StatementBuilder().setEffect("Allow").setHttpVerb(v).setResource(access.path).build());
@@ -16,13 +17,15 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     .map((i: IApiAccess[]) => i.map((ia) => toStatements(ia)).flat())
     .flat();
 
-  if (statements.length === 0) {
+    const dedupedFilters = statements.filter((item:MaybeStatementResource, pos:number, self:MaybeStatementResource[]) => { return self.findIndex(s => s.Resource === item.Resource) === pos });
+
+  if (dedupedFilters.length === 0) {
     return undefined;
   }
 
   const returnValue = {
     principalId: jwt.payload.sub as string,
-    policyDocument: newPolicyDocument(statements),
+    policyDocument: newPolicyDocument(dedupedFilters),
   };
 
   return returnValue;

--- a/tests/resources/jwt.json
+++ b/tests/resources/jwt.json
@@ -18,7 +18,14 @@
     "tid": "9122040d-6c67-4c5b-b112-36a304b66dad",
     "nonce": "123523",
     "aio": "Df2UVXL1ix!lMCWMSOJBcFatzcGfvFGhjKv8q5g0x732dR5MB5BisvGQO7YWByjd8iQDLq!eGbIDakyp5mnOrcdqHeYSnltepQmRp6AIZ8jY",
-    "roles": ["CVSFullAccess"]
+    "roles": [
+      "TechRecord.Amend",
+      "TestResult.Amend",
+      "TestResult.Archive",
+      "TestResult.View",
+      "TestResult.CreateContingency",
+      "TechRecord.View"
+    ]
   },
   "signature": "1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw"
 }

--- a/tests/unit/functions/authoriser.unitTest.ts
+++ b/tests/unit/functions/authoriser.unitTest.ts
@@ -123,27 +123,26 @@ describe("authorizer() unit tests", () => {
     const returnValue: APIGatewayAuthorizerResult = await authorizer(event, exampleContext());
 
     expect(returnValue.principalId).toEqual(jwtJson.payload.sub);
-    expect(returnValue.policyDocument.Statement.length).toEqual(7);
+    expect(returnValue.policyDocument.Statement.length).toEqual(6);
   });
 
   it("should return an accurate policy based on functional roles", async () => {
     (getLegacyRoles as jest.Mock) = jest.fn().mockReturnValue([]);
-    jwtJson.payload.roles = ["TechRecord.Amend"];
 
     const returnValue: APIGatewayAuthorizerResult = await authorizer(event, exampleContext());
 
     expect(returnValue.principalId).toEqual(jwtJson.payload.sub);
-    expect(returnValue.policyDocument.Statement.length).toEqual(5);
+    expect(returnValue.policyDocument.Statement.length).toEqual(6);
 
     const post: { Action: string; Effect: string; Resource: string } = returnValue.policyDocument.Statement[0] as unknown as { Action: string; Effect: string; Resource: string };
     expect(post.Effect).toEqual("Allow");
     expect(post.Action).toEqual("execute-api:Invoke");
-    expect(post.Resource).toEqual("arn:aws:execute-api:eu-west-1:*:*/*/POST/vehicles/*");
+    expect(post.Resource).toEqual("arn:aws:execute-api:eu-west-1:*:*/*/GET/vehicles/*");
 
     const put: { Action: string; Effect: string; Resource: string } = returnValue.policyDocument.Statement[1] as unknown as { Action: string; Effect: string; Resource: string };
     expect(put.Effect).toEqual("Allow");
     expect(put.Action).toEqual("execute-api:Invoke");
-    expect(put.Resource).toEqual("arn:aws:execute-api:eu-west-1:*:*/*/PUT/vehicles/*");
+    expect(put.Resource).toEqual("arn:aws:execute-api:eu-west-1:*:*/*/OPTIONS/vehicles/*");
   });
 
   it("should return an unauthorised policy response", async () => {


### PR DESCRIPTION
Permissions in the outputted IAM policy are generating duplicate statements - causing a config error.
The new code dedupes policy statements before returning