### PR TITLE
fix(cb2-6929): fix auth without CVSFullAccess

### DIFF
--- a/src/functions/authorizer.ts
+++ b/src/functions/authorizer.ts
@@ -32,16 +32,16 @@ export const authorizer = async (event: APIGatewayTokenAuthorizerEvent, context:
     const policy = generateRolePolicy(jwt, logEvent) ?? (await generateFunctionalPolicy(jwt, logEvent));
 
     if (policy !== undefined) {
-      console.log('final policy: ' + JSON.stringify(policy));
+      console.log("final policy: " + JSON.stringify(policy));
       return policy;
     }
 
-    console.log('no policy generated');
+    console.log("no policy generated");
     reportNoValidRoles(jwt, event, context, logEvent);
     writeLogMessage(logEvent, JWT_MESSAGE.INVALID_ROLES);
     return unauthorisedPolicy();
   } catch (error: any) {
-    console.log('Error: ' + JSON.stringify(error ?? {}));
+    console.log("Error: " + JSON.stringify(error ?? {}));
     writeLogMessage(logEvent, error);
     return unauthorisedPolicy();
   }

--- a/src/functions/authorizer.ts
+++ b/src/functions/authorizer.ts
@@ -32,16 +32,13 @@ export const authorizer = async (event: APIGatewayTokenAuthorizerEvent, context:
     const policy = generateRolePolicy(jwt, logEvent) ?? (await generateFunctionalPolicy(jwt, logEvent));
 
     if (policy !== undefined) {
-      console.log("final policy: " + JSON.stringify(policy));
       return policy;
     }
 
-    console.log("no policy generated");
     reportNoValidRoles(jwt, event, context, logEvent);
     writeLogMessage(logEvent, JWT_MESSAGE.INVALID_ROLES);
     return unauthorisedPolicy();
   } catch (error: any) {
-    console.log("Error: " + JSON.stringify(error ?? {}));
     writeLogMessage(logEvent, error);
     return unauthorisedPolicy();
   }

--- a/src/functions/authorizer.ts
+++ b/src/functions/authorizer.ts
@@ -29,7 +29,7 @@ export const authorizer = async (event: APIGatewayTokenAuthorizerEvent, context:
     initialiseLogEvent(event);
     const jwt = await getValidJwt(event.authorizationToken, logEvent, process.env.AZURE_TENANT_ID, process.env.AZURE_CLIENT_ID);
 
-    const policy = generateRolePolicy(jwt, logEvent) ?? (await generateFunctionalPolicy(jwt, logEvent));
+    const policy = generateRolePolicy(jwt, logEvent) ?? generateFunctionalPolicy(jwt, logEvent);
 
     if (policy !== undefined) {
       return policy;

--- a/src/functions/authorizer.ts
+++ b/src/functions/authorizer.ts
@@ -32,13 +32,16 @@ export const authorizer = async (event: APIGatewayTokenAuthorizerEvent, context:
     const policy = generateRolePolicy(jwt, logEvent) ?? (await generateFunctionalPolicy(jwt, logEvent));
 
     if (policy !== undefined) {
+      console.log('final policy: ' + JSON.stringify(policy));
       return policy;
     }
 
+    console.log('no policy generated');
     reportNoValidRoles(jwt, event, context, logEvent);
     writeLogMessage(logEvent, JWT_MESSAGE.INVALID_ROLES);
     return unauthorisedPolicy();
   } catch (error: any) {
+    console.log('Error: ' + JSON.stringify(error ?? {}));
     writeLogMessage(logEvent, error);
     return unauthorisedPolicy();
   }

--- a/src/functions/functionalPolicyFactory.ts
+++ b/src/functions/functionalPolicyFactory.ts
@@ -21,11 +21,6 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     return self.findIndex((s) => s.Resource === item.Resource) === pos;
   });
 
-  console.log(`payload roles: ${JSON.stringify((jwt.payload as JwtPayload).roles)}`);
-  console.log(`original statements: ${JSON.stringify(statements)}`);
-  console.log(`deduperFilters: ${JSON.stringify(dedupedFilters)}`);
-  console.log(`deduperFilters length: ${dedupedFilters.length}`);
-
   if (dedupedFilters.length === 0) {
     return undefined;
   }

--- a/src/functions/functionalPolicyFactory.ts
+++ b/src/functions/functionalPolicyFactory.ts
@@ -21,6 +21,11 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     return self.findIndex((s) => s.Resource === item.Resource) === pos;
   });
 
+  console.log(`payload roles: ${JSON.stringify((jwt.payload as JwtPayload).roles)}`);
+  console.log(`original statements: ${JSON.stringify(statements)}`);
+  console.log(`deduperFilters: ${JSON.stringify(dedupedFilters)}`);
+  console.log(`deduperFilters length: ${dedupedFilters.length}`);
+
   if (dedupedFilters.length === 0) {
     return undefined;
   }

--- a/src/functions/functionalPolicyFactory.ts
+++ b/src/functions/functionalPolicyFactory.ts
@@ -17,7 +17,9 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     .map((i: IApiAccess[]) => i.map((ia) => toStatements(ia)).flat())
     .flat();
 
-    const dedupedFilters = statements.filter((item:MaybeStatementResource, pos:number, self:MaybeStatementResource[]) => { return self.findIndex(s => s.Resource === item.Resource) === pos });
+  const dedupedFilters = statements.filter((item: MaybeStatementResource, pos: number, self: MaybeStatementResource[]) => {
+    return self.findIndex((s) => s.Resource === item.Resource) === pos;
+  });
 
   if (dedupedFilters.length === 0) {
     return undefined;

--- a/src/functions/functionalPolicyFactory.ts
+++ b/src/functions/functionalPolicyFactory.ts
@@ -1,9 +1,10 @@
-import { APIGatewayAuthorizerResult, Statement } from "aws-lambda";
+import { APIGatewayAuthorizerResult, MaybeStatementResource, Statement, StatementResource } from "aws-lambda";
 import newPolicyDocument from "./newPolicyDocument";
 import { ILogEvent } from "../models/ILogEvent";
 import StatementBuilder from "../services/StatementBuilder";
 import { functionConfig, IApiAccess } from "./functionalConfig";
 import { Jwt, JwtPayload } from "jsonwebtoken";
+import { ResourceStatement } from "aws-sdk/clients/ec2";
 
 function toStatements(access: IApiAccess): Statement[] {
   return access.verbs.map((v) => new StatementBuilder().setEffect("Allow").setHttpVerb(v).setResource(access.path).build());
@@ -16,13 +17,15 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     .map((i: IApiAccess[]) => i.map((ia) => toStatements(ia)).flat())
     .flat();
 
-  if (statements.length === 0) {
+    const dedupedFilters = statements.filter((item:MaybeStatementResource, pos:number, self:MaybeStatementResource[]) => { return self.findIndex(s => s.Resource === item.Resource) === pos });
+
+  if (dedupedFilters.length === 0) {
     return undefined;
   }
 
   const returnValue = {
     principalId: jwt.payload.sub as string,
-    policyDocument: newPolicyDocument(statements),
+    policyDocument: newPolicyDocument(dedupedFilters),
   };
 
   return returnValue;

--- a/src/functions/rolePolicyFactory.ts
+++ b/src/functions/rolePolicyFactory.ts
@@ -78,9 +78,10 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     statements = statements.concat(items);
   }
 
-  console.log(`statement length: ${statements ? statements.length : "-"}`);
-  console.log(`legacy roles length: ${legacyRoles ? legacyRoles.length : "-"}`);
-  console.log(`legacy policy: ${JSON.stringify(statements)}`);
+  if(!statements || statements.length === 0)
+  {
+    return undefined;
+  }
 
   return {
     principalId: jwt.payload.sub as string,

--- a/src/functions/rolePolicyFactory.ts
+++ b/src/functions/rolePolicyFactory.ts
@@ -78,7 +78,7 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     statements = statements.concat(items);
   }
 
-  console.log(`legacy policy: ${JSON.stringify(statements)}`)
+  console.log(`legacy policy: ${JSON.stringify(statements)}`);
 
   return {
     principalId: jwt.payload.sub as string,

--- a/src/functions/rolePolicyFactory.ts
+++ b/src/functions/rolePolicyFactory.ts
@@ -78,8 +78,8 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     statements = statements.concat(items);
   }
 
-  console.log(`statement length: ${statements ? statements.length : '-'}`);
-  console.log(`legacy roles length: ${legacyRoles ? legacyRoles.length : '-'}`);
+  console.log(`statement length: ${statements ? statements.length : "-"}`);
+  console.log(`legacy roles length: ${legacyRoles ? legacyRoles.length : "-"}`);
   console.log(`legacy policy: ${JSON.stringify(statements)}`);
 
   return {

--- a/src/functions/rolePolicyFactory.ts
+++ b/src/functions/rolePolicyFactory.ts
@@ -78,6 +78,8 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     statements = statements.concat(items);
   }
 
+  console.log(`statement length: ${statements ? statements.length : '-'}`);
+  console.log(`legacy roles length: ${legacyRoles ? legacyRoles.length : '-'}`);
   console.log(`legacy policy: ${JSON.stringify(statements)}`);
 
   return {

--- a/src/functions/rolePolicyFactory.ts
+++ b/src/functions/rolePolicyFactory.ts
@@ -78,8 +78,7 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     statements = statements.concat(items);
   }
 
-  if(!statements || statements.length === 0)
-  {
+  if (!statements || statements.length === 0) {
     return undefined;
   }
 

--- a/src/functions/rolePolicyFactory.ts
+++ b/src/functions/rolePolicyFactory.ts
@@ -78,6 +78,8 @@ export function generatePolicy(jwt: Jwt, logEvent: ILogEvent): APIGatewayAuthori
     statements = statements.concat(items);
   }
 
+  console.log(`legacy policy: ${JSON.stringify(statements)}`)
+
   return {
     principalId: jwt.payload.sub as string,
     policyDocument: newPolicyDocument(statements),

--- a/tests/resources/jwt.json
+++ b/tests/resources/jwt.json
@@ -18,7 +18,14 @@
     "tid": "9122040d-6c67-4c5b-b112-36a304b66dad",
     "nonce": "123523",
     "aio": "Df2UVXL1ix!lMCWMSOJBcFatzcGfvFGhjKv8q5g0x732dR5MB5BisvGQO7YWByjd8iQDLq!eGbIDakyp5mnOrcdqHeYSnltepQmRp6AIZ8jY",
-    "roles": ["CVSFullAccess"]
+    "roles": [
+      "TechRecord.Amend",
+      "TestResult.Amend",
+      "TestResult.Archive",
+      "TestResult.View",
+      "TestResult.CreateContingency",
+      "TechRecord.View"
+    ]
   },
   "signature": "1AFWW-Ck5nROwSlltm7GzZvDwUkqvhSQpm55TQsmVo9Y59cLhRXpvB8n-55HCr9Z6G_31_UbeUkoz612I2j_Sm9FFShSDDjoaLQr54CreGIJvjtmS3EkK9a7SJBbcpL1MpUtlfygow39tFjY7EVNW9plWUvRrTgVk7lYLprvfzw-CIqw3gHC-T7IK_m_xkr08INERBtaecwhTeN4chPC4W3jdmw_lIxzC48YoQ0dB1L9-ImX98Egypfrlbm0IBL5spFzL6JDZIRRJOu8vecJvj1mq-IUhGt0MacxX8jdxYLP-KUu2d9MbNKpCKJuZ7p8gwTL5B7NlUdh_dmSviPWrw"
 }

--- a/tests/unit/functions/authoriser.unitTest.ts
+++ b/tests/unit/functions/authoriser.unitTest.ts
@@ -123,27 +123,26 @@ describe("authorizer() unit tests", () => {
     const returnValue: APIGatewayAuthorizerResult = await authorizer(event, exampleContext());
 
     expect(returnValue.principalId).toEqual(jwtJson.payload.sub);
-    expect(returnValue.policyDocument.Statement.length).toEqual(7);
+    expect(returnValue.policyDocument.Statement.length).toEqual(6);
   });
 
   it("should return an accurate policy based on functional roles", async () => {
     (getLegacyRoles as jest.Mock) = jest.fn().mockReturnValue([]);
-    jwtJson.payload.roles = ["TechRecord.Amend"];
 
     const returnValue: APIGatewayAuthorizerResult = await authorizer(event, exampleContext());
 
     expect(returnValue.principalId).toEqual(jwtJson.payload.sub);
-    expect(returnValue.policyDocument.Statement.length).toEqual(5);
+    expect(returnValue.policyDocument.Statement.length).toEqual(6);
 
     const post: { Action: string; Effect: string; Resource: string } = returnValue.policyDocument.Statement[0] as unknown as { Action: string; Effect: string; Resource: string };
     expect(post.Effect).toEqual("Allow");
     expect(post.Action).toEqual("execute-api:Invoke");
-    expect(post.Resource).toEqual("arn:aws:execute-api:eu-west-1:*:*/*/POST/vehicles/*");
+    expect(post.Resource).toEqual("arn:aws:execute-api:eu-west-1:*:*/*/GET/vehicles/*");
 
     const put: { Action: string; Effect: string; Resource: string } = returnValue.policyDocument.Statement[1] as unknown as { Action: string; Effect: string; Resource: string };
     expect(put.Effect).toEqual("Allow");
     expect(put.Action).toEqual("execute-api:Invoke");
-    expect(put.Resource).toEqual("arn:aws:execute-api:eu-west-1:*:*/*/PUT/vehicles/*");
+    expect(put.Resource).toEqual("arn:aws:execute-api:eu-west-1:*:*/*/OPTIONS/vehicles/*");
   });
 
   it("should return an unauthorised policy response", async () => {


### PR DESCRIPTION
## Bug: TechRecord.View permission doesn't allow searching for a Technical Record

You could not search for a tech record without CVSFullAccess. This bug was caused by the code accidentally entering the old policy section and then returning an empty array. This has been repaired in this PR and also includes another small fix to remove duplicate policies being added.
[https://dvsa.atlassian.net/browse/CB2-6929](6929)

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number
