### PR TITLE
Correct issue with document retrieval endpoint

### DIFF
--- a/src/functions/functionalConfig.ts
+++ b/src/functions/functionalConfig.ts
@@ -121,7 +121,7 @@ export const functionConfig: { [key: string]: NonEmptyArray<IApiAccess> } = {
     },
     {
       verbs: ["GET", "OPTIONS"],
-      path: "v1/document-retrieval/*",
+      path: "v1/document-retrieval",
     },
   ],
 };


### PR DESCRIPTION
Document retrieval endpoint had an incorrect `/*` suffix
