### PR TITLE
feat(cb2-8066): add permissions for get tech records v2

### DIFF
--- a/src/functions/functionalConfig.ts
+++ b/src/functions/functionalConfig.ts
@@ -35,6 +35,10 @@ export const functionConfig: { [key: string]: NonEmptyArray<IApiAccess> } = {
       verbs: ["GET", "OPTIONS"],
       path: "vehicles/*",
     },
+    {
+      verbs: ["GET", "OPTIONS"],
+      path: "v2/vehicles/{searchIdentifier}/tech-records/"
+    }
   ],
   "TechRecord.Archive": [
     {

--- a/src/functions/functionalConfig.ts
+++ b/src/functions/functionalConfig.ts
@@ -27,6 +27,10 @@ export const functionConfig: { [key: string]: NonEmptyArray<IApiAccess> } = {
     },
     {
       verbs: ["GET", "OPTIONS"],
+      path: "v2/vehicles/*",
+    },
+    {
+      verbs: ["GET", "OPTIONS"],
       path: "reference/*",
     },
   ],

--- a/src/functions/functionalConfig.ts
+++ b/src/functions/functionalConfig.ts
@@ -37,8 +37,8 @@ export const functionConfig: { [key: string]: NonEmptyArray<IApiAccess> } = {
     },
     {
       verbs: ["GET", "OPTIONS"],
-      path: "v2/vehicles/{searchIdentifier}/tech-records/*"
-    }
+      path: "v2/vehicles/*",
+    },
   ],
   "TechRecord.Archive": [
     {
@@ -146,12 +146,12 @@ export const functionConfig: { [key: string]: NonEmptyArray<IApiAccess> } = {
     {
       verbs: ["GET", "OPTIONS"],
       path: "reference/*",
-    }
+    },
   ],
   "ReferenceData.Amend": [
     {
       verbs: ["GET", "OPTIONS", "PUT", "POST", "DELETE"],
       path: "reference/*",
-    }
+    },
   ],
 };

--- a/src/functions/functionalConfig.ts
+++ b/src/functions/functionalConfig.ts
@@ -37,7 +37,7 @@ export const functionConfig: { [key: string]: NonEmptyArray<IApiAccess> } = {
     },
     {
       verbs: ["GET", "OPTIONS"],
-      path: "v2/vehicles/{searchIdentifier}/tech-records/"
+      path: "v2/vehicles/{searchIdentifier}/tech-records/*"
     }
   ],
   "TechRecord.Archive": [

--- a/tests/unit/functions/authoriser.unitTest.ts
+++ b/tests/unit/functions/authoriser.unitTest.ts
@@ -20,7 +20,7 @@ describe("authorizer() unit tests", () => {
   });
 
   it("should fail on non-2xx HTTP status", async () => {
-    (getValidJwt as jest.Mock) = jest.fn().mockRejectedValue({ statusCode: 418, body: "I'm a teapot", options: { url: "http://example.org" }, response: {} as IncomingMessage});
+    (getValidJwt as jest.Mock) = jest.fn().mockRejectedValue({ statusCode: 418, body: "I'm a teapot", options: { url: "http://example.org" }, response: {} as IncomingMessage });
 
     await expectUnauthorised(event);
   });
@@ -107,7 +107,7 @@ describe("authorizer() unit tests", () => {
 
     expect(returnValue.principalId).toEqual(jwtJson.payload.sub);
 
-    expect(returnValue.policyDocument.Statement.length).toEqual(2);
+    expect(returnValue.policyDocument.Statement.length).toEqual(4);
     expect(returnValue.policyDocument.Statement).toContainEqual({
       Effect: "Allow",
       Action: "execute-api:Invoke",
@@ -122,7 +122,7 @@ describe("authorizer() unit tests", () => {
     const returnValue: APIGatewayAuthorizerResult = await authorizer(event, exampleContext());
 
     expect(returnValue.principalId).toEqual(jwtJson.payload.sub);
-    expect(returnValue.policyDocument.Statement.length).toEqual(6);
+    expect(returnValue.policyDocument.Statement.length).toEqual(8);
   });
 
   it("should return an accurate policy based on functional roles", async () => {
@@ -131,7 +131,7 @@ describe("authorizer() unit tests", () => {
     const returnValue: APIGatewayAuthorizerResult = await authorizer(event, exampleContext());
 
     expect(returnValue.principalId).toEqual(jwtJson.payload.sub);
-    expect(returnValue.policyDocument.Statement.length).toEqual(6);
+    expect(returnValue.policyDocument.Statement.length).toEqual(8);
 
     const post: { Action: string; Effect: string; Resource: string } = returnValue.policyDocument.Statement[0] as unknown as { Action: string; Effect: string; Resource: string };
     expect(post.Effect).toEqual("Allow");


### PR DESCRIPTION
## Ticket title

Users with permissions to call the `GET /vehicles` endpoint should also have permissions to call the `GET /v2/vehicles` endpoint 
[CB2-8066](https://dvsa.atlassian.net/browse/CB2-8066)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
