### PR TITLE
VTA-1660: Add jwt log when unauthorised policy is returned

### DIFF
--- a/src/common/Logger.ts
+++ b/src/common/Logger.ts
@@ -2,7 +2,7 @@ import { ILogEvent } from "../models/ILogEvent";
 import { JWT_MESSAGE } from "../models/enums";
 import { ILogError } from "../models/ILogError";
 
-export const writeLogMessage = (log: ILogEvent, error?: any) => {
+export const writeLogMessage = (log: ILogEvent, jwt: string, error?: any) => {
   if (!error) {
     log.statusCode = 200;
     console.log(log);
@@ -33,6 +33,7 @@ export const writeLogMessage = (log: ILogEvent, error?: any) => {
     }
     log.error = logError;
     console.error(log);
+    console.log(jwt);
   }
   return log;
 };

--- a/src/common/Logger.ts
+++ b/src/common/Logger.ts
@@ -32,8 +32,8 @@ export const writeLogMessage = (log: ILogEvent, jwt: string, error?: any) => {
       }
     }
     log.error = logError;
+    log.error.token = jwt;
     console.error(log);
-    console.log(jwt);
   }
   return log;
 };

--- a/src/functions/authorizer.ts
+++ b/src/functions/authorizer.ts
@@ -21,7 +21,7 @@ export const authorizer = async (event: APIGatewayTokenAuthorizerEvent, context:
   const logEvent: ILogEvent = {};
 
   if (!process.env.AZURE_TENANT_ID || !process.env.AZURE_CLIENT_ID) {
-    writeLogMessage(logEvent, JWT_MESSAGE.INVALID_ID_SETUP);
+    writeLogMessage(logEvent, event.authorizationToken, JWT_MESSAGE.INVALID_ID_SETUP);
     return unauthorisedPolicy();
   }
 
@@ -36,10 +36,10 @@ export const authorizer = async (event: APIGatewayTokenAuthorizerEvent, context:
     }
 
     reportNoValidRoles(jwt, event, context, logEvent);
-    writeLogMessage(logEvent, JWT_MESSAGE.INVALID_ROLES);
+    writeLogMessage(logEvent, event.authorizationToken, JWT_MESSAGE.INVALID_ROLES);
     return unauthorisedPolicy();
   } catch (error: any) {
-    writeLogMessage(logEvent, error);
+    writeLogMessage(logEvent, event.authorizationToken, error);
     return unauthorisedPolicy();
   }
 };

--- a/src/models/ILogError.ts
+++ b/src/models/ILogError.ts
@@ -1,4 +1,5 @@
 export interface ILogError {
   name?: string;
   message?: string;
+  token?: string;
 }

--- a/tests/unit/common/Logger.unitTest.ts
+++ b/tests/unit/common/Logger.unitTest.ts
@@ -11,7 +11,7 @@ describe("test writeLogMessage method", () => {
 
   context("when only the log event is passed in", () => {
     it("should return no errors", () => {
-      const returnValue: ILogEvent = writeLogMessage(successLogEvent, null);
+      const returnValue: ILogEvent = writeLogMessage(successLogEvent, "mock-jwt", null);
 
       expect(returnValue.statusCode).toBe(200);
     });
@@ -20,41 +20,49 @@ describe("test writeLogMessage method", () => {
   context("when log event and error are passed in", () => {
     it("should log TokenExpiredError", () => {
       const error: ILogError = { name: "TokenExpiredError", message: "Error" };
+      console.log = jest.fn();
 
       logError.name = "TokenExpiredError";
-      const returnValue: ILogEvent = writeLogMessage(logErrorEvent, error);
+      const returnValue: ILogEvent = writeLogMessage(logErrorEvent,"mock-jwt", error);
 
       expect(returnValue.error?.name).toBe("TokenExpiredError");
       expect(returnValue.error?.message).toBe("[JWT-ERROR-07] Error at undefined");
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('mock-jwt'));
     });
 
     it("should log NotBeforeError", () => {
       const error: ILogError = { name: "NotBeforeError" };
+      console.log = jest.fn();
 
       logError.name = "NotBeforeError";
-      const returnValue: ILogEvent = writeLogMessage(logErrorEvent, error);
+      const returnValue: ILogEvent = writeLogMessage(logErrorEvent,"mock-jwt", error);
 
       expect(returnValue.error?.name).toBe("NotBeforeError");
       expect(returnValue.error?.message).toBe("[JWT-ERROR-08] undefined until undefined");
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('mock-jwt'));
     });
 
     it("should log JsonWebTokenError", () => {
       const error: ILogError = { name: "JsonWebTokenError", message: "test" };
+      console.log = jest.fn();
 
       logError.name = "JsonWebTokenError";
-      const returnValue: ILogEvent = writeLogMessage(logErrorEvent, error);
+      const returnValue: ILogEvent = writeLogMessage(logErrorEvent,"mock-jwt", error);
 
       expect(returnValue.error?.name).toBe("JsonWebTokenError");
       expect(returnValue.error?.message).toBe("[JWT-ERROR-09] test");
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('mock-jwt'));
     });
 
     it("should log the default error", () => {
       const error: ILogError = { name: "Error", message: "Error" };
+      console.log = jest.fn();
 
-      const returnValue: ILogEvent = writeLogMessage(logErrorEvent, error);
+      const returnValue: ILogEvent = writeLogMessage(logErrorEvent,"mock-jwt", error);
 
       expect(returnValue.error?.name).toBe("Error");
       expect(returnValue.error?.message).toBe("Error");
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('mock-jwt'));
     });
   });
 });

--- a/tests/unit/common/Logger.unitTest.ts
+++ b/tests/unit/common/Logger.unitTest.ts
@@ -27,7 +27,7 @@ describe("test writeLogMessage method", () => {
 
       expect(returnValue.error?.name).toBe("TokenExpiredError");
       expect(returnValue.error?.message).toBe("[JWT-ERROR-07] Error at undefined");
-      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('mock-jwt'));
+      expect(returnValue.error?.token).toBe("mock-jwt");
     });
 
     it("should log NotBeforeError", () => {
@@ -39,7 +39,7 @@ describe("test writeLogMessage method", () => {
 
       expect(returnValue.error?.name).toBe("NotBeforeError");
       expect(returnValue.error?.message).toBe("[JWT-ERROR-08] undefined until undefined");
-      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('mock-jwt'));
+      expect(returnValue.error?.token).toBe("mock-jwt");
     });
 
     it("should log JsonWebTokenError", () => {
@@ -51,7 +51,7 @@ describe("test writeLogMessage method", () => {
 
       expect(returnValue.error?.name).toBe("JsonWebTokenError");
       expect(returnValue.error?.message).toBe("[JWT-ERROR-09] test");
-      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('mock-jwt'));
+      expect(returnValue.error?.token).toBe("mock-jwt");
     });
 
     it("should log the default error", () => {
@@ -62,7 +62,7 @@ describe("test writeLogMessage method", () => {
 
       expect(returnValue.error?.name).toBe("Error");
       expect(returnValue.error?.message).toBe("Error");
-      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('mock-jwt'));
+      expect(returnValue.error?.token).toBe("mock-jwt");
     });
   });
 });


### PR DESCRIPTION
## Revert JWT log in Authoriser (for unauthorised calls)

Add JWT log back into VTA, it was removed but the logs are required to identify a current issue VTA is experiencing and will help define remediation work within VTA.

The JWT will only be logged if the user would get an unauthorised response.

[link to ticket number]()

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
