### PR TITLE
feat(CB2-14070): Add test stations to CSC and Tech Officer user roles

### DIFF
--- a/src/functions/functionalConfig.ts
+++ b/src/functions/functionalConfig.ts
@@ -78,6 +78,10 @@ export const functionConfig: { [key: string]: NonEmptyArray<IApiAccess> } = {
       path: "test-results",
     },
     {
+      verbs: ["GET"],
+      path: "test-stations",
+    },
+    {
       verbs: ["GET", "OPTIONS"],
       path: "test-stations/*",
     },
@@ -112,6 +116,10 @@ export const functionConfig: { [key: string]: NonEmptyArray<IApiAccess> } = {
       path: "test-types/*",
     },
     {
+      verbs: ["GET"],
+      path: "test-stations",
+    },
+    {
       verbs: ["GET", "OPTIONS"],
       path: "test-stations/*",
     },
@@ -136,6 +144,10 @@ export const functionConfig: { [key: string]: NonEmptyArray<IApiAccess> } = {
     {
       verbs: ["GET", "OPTIONS"],
       path: "test-types/*",
+    },
+    {
+      verbs: ["GET"],
+      path: "test-stations",
     },
     {
       verbs: ["GET", "OPTIONS"],


### PR DESCRIPTION
## CSC users can't select a test station when creating a contingency test for test type 199

This change is to allow CSC and Tech Officers to retrieve test stations.
[CB2-14070](https://dvsa.atlassian.net/browse/CB2-14070)

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
